### PR TITLE
Fix: log message when validating template

### DIFF
--- a/src/sanger_sequencing/validation/template.py
+++ b/src/sanger_sequencing/validation/template.py
@@ -110,5 +110,5 @@ def drop_missing_records(
     if (~sample_mask).any():
         LOGGER.error(
             "The following sample(s) have no corresponding sequence record: "
-            "%s.", ", ".join(template.loc[plasmid_mask, "sample"]))
+            "%s.", ", ".join(template.loc[sample_mask, "sample"]))
     return template.loc[plasmid_mask & sample_mask, :]


### PR DESCRIPTION
When providing a valid sample name and an invalid one, the error message in the log states that both samples names are invalid:

> No ab1 file found for tube with code 'invalid tube code'.
> The following sample(s) have no corresponding sequence record: invalid tube code, FR14453278

* [ ] fix #x (issue number)
* [ ] description of feature/fix
* [ ] tests added/passed
* [ ] add an entry to the [change log](CHANGELOG.rst)
